### PR TITLE
Add metrics profile endpoint and extend tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import auth, habits, marks
+from app.routes import auth, habits, marks, profile
 from app.models import Base
 from app.db import engine
 
@@ -33,6 +33,7 @@ app.add_middleware(
 app.include_router(auth.router, prefix="/api")
 app.include_router(habits.router, prefix="/api")
 app.include_router(marks.router, prefix="/api")
+app.include_router(profile.router, prefix="/api")
 
 
 @app.get("/")

--- a/backend/app/routes/profile.py
+++ b/backend/app/routes/profile.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from datetime import date
+
+from app.db import get_db
+from app.models import User, Habit, Mark
+from app.auth import get_current_user
+
+router = APIRouter(prefix="/profile", tags=["profile"])
+
+@router.get("/metrics")
+async def get_metrics(current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    total_habits = db.query(Habit).filter(Habit.user_id == current_user.id).count()
+    archived_habits = db.query(Habit).filter(Habit.user_id == current_user.id, Habit.archived.is_(True)).count()
+    completed_habits = db.query(Habit).filter(Habit.user_id == current_user.id, Habit.completed.is_(True)).count()
+    active_habits = db.query(Habit).filter(Habit.user_id == current_user.id, Habit.archived.is_(False)).count()
+    marks_total = db.query(Mark).join(Habit).filter(Habit.user_id == current_user.id).count()
+    marks_today = db.query(Mark).join(Habit).filter(Habit.user_id == current_user.id, Mark.date == date.today()).count()
+    return {
+        "total_habits": total_habits,
+        "archived_habits": archived_habits,
+        "completed_habits": completed_habits,
+        "active_habits": active_habits,
+        "marks_total": marks_total,
+        "marks_today": marks_today,
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,6 @@ async def authenticated_client():
 @pytest_asyncio.fixture
 async def authenticated_client_with_habit(authenticated_client):
     ac = authenticated_client
-    response = await ac.post("/api/habits", json={"name": "Exercise", "description": "Daily exercise"})
+    response = await ac.post("/api/habits/", json={"name": "Exercise", "description": "Daily exercise"})
     habit_id = response.json()["id"]
     return ac, habit_id

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -64,3 +64,18 @@ async def test_protected_route_requires_token():
     async with AsyncClient(app=app, base_url="http://test") as ac:
         r = await ac.get("/api/habits/")          # без заголовка Authorization
         assert r.status_code == 401
+
+@pytest.mark.asyncio
+async def test_login_wrong_password():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        uname = f"user_{uuid.uuid4().hex[:6]}"
+        await ac.post("/api/auth/register", json={"username": uname, "password": "goodpass"})
+        r = await ac.post("/api/auth/login", json={"username": uname, "password": "otherpass"})
+        assert r.status_code == 401
+
+@pytest.mark.asyncio
+async def test_invalid_token_access():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        ac.headers.update({"Authorization": "Bearer invalid"})
+        r = await ac.get("/api/habits/")
+        assert r.status_code == 401

--- a/backend/tests/test_habits.py
+++ b/backend/tests/test_habits.py
@@ -33,3 +33,24 @@ async def test_update_habit_not_found(authenticated_client):
     bad_id = uuid.uuid4()
     r = await authenticated_client.put(f"/api/habits/{bad_id}", json={"name":"X"})
     assert r.status_code == 404
+@pytest.mark.asyncio
+async def test_complete_and_uncomplete_habit(authenticated_client_with_habit):
+    ac, habit_id = authenticated_client_with_habit
+    r = await ac.post(f"/api/habits/{habit_id}/complete")
+    assert r.status_code == 204
+
+    completed = await ac.get("/api/habits/completed")
+    assert habit_id in [h["id"] for h in completed.json()]
+
+    r = await ac.post(f"/api/habits/{habit_id}/uncomplete")
+    assert r.status_code == 204
+    completed = await ac.get("/api/habits/completed")
+    assert habit_id not in [h["id"] for h in completed.json()]
+
+@pytest.mark.asyncio
+async def test_delete_habit(authenticated_client_with_habit):
+    ac, habit_id = authenticated_client_with_habit
+    r = await ac.delete(f"/api/habits/{habit_id}")
+    assert r.status_code == 204
+    r = await ac.get("/api/habits/")
+    assert habit_id not in [h["id"] for h in r.json()]

--- a/backend/tests/test_marks.py
+++ b/backend/tests/test_marks.py
@@ -1,0 +1,20 @@
+import pytest
+from datetime import date
+
+@pytest.mark.asyncio
+async def test_create_and_delete_mark(authenticated_client_with_habit):
+    ac, habit_id = authenticated_client_with_habit
+    r = await ac.post("/api/marks/", json={"habit_id": habit_id, "date": date.today().isoformat()})
+    assert r.status_code == 200
+    mark_id = r.json()["id"]
+
+    r = await ac.get(f"/api/marks/habit/{habit_id}")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+    r = await ac.delete(f"/api/marks/{mark_id}")
+    assert r.status_code == 204
+
+    r = await ac.get(f"/api/marks/habit/{habit_id}")
+    assert r.status_code == 200
+    assert len(r.json()) == 0

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -1,0 +1,21 @@
+import pytest
+from httpx import AsyncClient
+from datetime import date
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_profile_metrics(authenticated_client_with_habit):
+    ac, habit_id = authenticated_client_with_habit
+    # add mark for today
+    r = await ac.post("/api/marks/", json={"habit_id": habit_id, "date": date.today().isoformat()})
+    assert r.status_code == 200
+
+    metrics = await ac.get("/api/profile/metrics")
+    body = metrics.json()
+    assert metrics.status_code == 200
+    assert body["total_habits"] == 1
+    assert body["active_habits"] == 1
+    assert body["completed_habits"] == 0
+    assert body["archived_habits"] == 0
+    assert body["marks_total"] == 1
+    assert body["marks_today"] == 1


### PR DESCRIPTION
## Summary
- add `/profile/metrics` endpoint for user habit stats
- include profile router in API
- create tests for marks and metrics
- extend habit tests and auth negative tests
- adjust fixtures for consistent URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844128c9ba083338be391788094bbd0