### PR TITLE
Add Telegram bot service

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ cd habit_tracker
 
 | Service  | URL                                            |
 | -------- | ---------------------------------------------- |
-| Backend  | [http://localhost:8000](http://localhost:8000) |
-| Frontend | [http://localhost:3000](http://localhost:3000) |                     
+| Backend      | [http://localhost:8000](http://localhost:8000) |
+| Frontend     | [http://localhost:3000](http://localhost:3000) |
+| Telegram Bot | -- requires `BOT_TOKEN` env -- |
+
+Set `BOT_TOKEN` in your environment before running `./main.sh` to enable the bot.
 
 Front-end is a static SPA (HTML / CSS / vanilla JS) served by Nginx.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,16 @@ services:
     networks: [habit-network]
     restart: always
 
+  # ──────────── telegram bot ────────────
+  telegram-bot:
+    build: ./telegram_bot
+    environment:
+      - BOT_TOKEN=${BOT_TOKEN}
+    depends_on:
+      - backend
+    networks: [habit-network]
+    restart: always
+
   # ──────────── Postgres ────────────
   db:
     image: postgres:13

--- a/telegram_bot/Dockerfile
+++ b/telegram_bot/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.9-slim
+WORKDIR /app
+COPY bot.py .
+RUN pip install --no-cache-dir python-telegram-bot==20.3
+CMD ["python", "bot.py"]

--- a/telegram_bot/bot.py
+++ b/telegram_bot/bot.py
@@ -1,0 +1,18 @@
+import os
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+TOKEN = os.getenv("BOT_TOKEN")
+if not TOKEN:
+    raise RuntimeError("BOT_TOKEN environment variable is required")
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.message.reply_text("Habit Tracker Bot is running")
+
+def main():
+    app = ApplicationBuilder().token(TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    app.run_polling()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Telegram bot service
- document Telegram bot usage

## Testing
- `./tests.sh` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68808e1ad46c83338d7d03393e25f98c